### PR TITLE
Clang 8 and gcc/g++ 10.2.0 fix

### DIFF
--- a/include/jnivm/class.h
+++ b/include/jnivm/class.h
@@ -103,7 +103,7 @@ namespace jnivm {
             }
         };
 
-        template<class T, FunctionType bind, bool EnvArg> struct HookManagerHelper2<T, bind, EnvArg, std::enable_if_t<(((int)bind & (int)FunctionType::Getter) && Function<T>::plength > (EnvArg ? 1 : 0) || ((int)bind & (int)FunctionType::Setter) && Function<T>::plength > (EnvArg ? 2 : 1))>> {
+        template<class T, FunctionType bind, bool EnvArg> struct HookManagerHelper2<T, bind, EnvArg, std::enable_if_t<((((int)bind & (int)FunctionType::Getter) && Function<T>::plength > (EnvArg ? 1 : 0)) || (((int)bind & (int)FunctionType::Setter) && Function<T>::plength > (EnvArg ? 2 : 1)))>> {
             static void install(ENV* env, Class* cl, const std::string& id, T&& t) {
                 impl::HookManagerHelper<T, bind, EnvArg ? 1 : 0>::install(env, cl, id, std::move(t));
             }

--- a/src/jnivm/internal/method.cpp
+++ b/src/jnivm/internal/method.cpp
@@ -336,3 +336,16 @@ DeclareTemplate(jchar);
 DeclareTemplate(jobject);
 DeclareTemplate(void);
 #undef DeclareTemplate
+
+#define DeclareTemplate(T) template T jnivm::defaultVal(ENV* env, std::string signature)
+DeclareTemplate(jboolean);
+DeclareTemplate(jbyte);
+DeclareTemplate(jshort);
+DeclareTemplate(jint);
+DeclareTemplate(jlong);
+DeclareTemplate(jfloat);
+DeclareTemplate(jdouble);
+DeclareTemplate(jchar);
+DeclareTemplate(jobject);
+DeclareTemplate(void);
+#undef DeclareTemplate

--- a/src/jnivm/method.cpp
+++ b/src/jnivm/method.cpp
@@ -102,3 +102,15 @@ jvalue Method::jinvoke(jnivm::ENV &env, jobject obj, ...) {
 	va_end(l);
 	return ret;
 }
+
+#define DeclareTemplate(T) template jvalue toJValue(T val);
+DeclareTemplate(jboolean);
+DeclareTemplate(jbyte);
+DeclareTemplate(jshort);
+DeclareTemplate(jint);
+DeclareTemplate(jlong);
+DeclareTemplate(jfloat);
+DeclareTemplate(jdouble);
+DeclareTemplate(jchar);
+DeclareTemplate(jobject);
+#undef DeclareTemplate

--- a/src/jnivm/vm.cpp
+++ b/src/jnivm/vm.cpp
@@ -566,3 +566,6 @@ jnivm::VM *jnivm::VM::FromJavaVM(JavaVM *vm) {
 	if(vm == nullptr || vm->functions->reserved0 == nullptr) throw std::runtime_error("Failed to get reference to jnivm::VM");
     return static_cast<jnivm::VM*>(vm->functions->reserved0);
 }
+
+template JNINativeInterface jnivm::VM::GetNativeInterfaceTemplate<true>();
+template JNINativeInterface jnivm::VM::GetNativeInterfaceTemplate<false>();


### PR DESCRIPTION
Fix linker errors of some c++ compilers.
Implicit template instances aren't always exported.

Resolves #7