### PR TITLE
Update google test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if(JNIVM_ENABLE_TESTS)
     FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG        release-1.10.0
+    GIT_TAG        v1.13.0
     )
     
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
I'm not a fan of -Werror breaking the ci in googletest